### PR TITLE
[semver:patch] ensure loading of the right Deepl API key

### DIFF
--- a/src/scripts/translate.sh
+++ b/src/scripts/translate.sh
@@ -1,5 +1,9 @@
 #! /usr/bin/env bash
 
+# DEEPL_API_KEY is originally passed in indicating the env var name
+# to locate the Deepl API key.
+DEEPL_API_KEY=$(eval echo "\$$DEEPL_API_KEY")
+
 if [ ! "$(command -v curl)" ]; then
     echo "curl is required but not found. Exiting"
     exit 1


### PR DESCRIPTION
This is a fix on the script as I realized `deepl-api-key` is a `env_var_name` type argument.
As such, its content is the location (i.e., which env var) to the Deepl API key.

This fix is referenced from CircleCI's aws-cli Orb:
https://github.com/CircleCI-Public/aws-cli-orb/blob/01608439d905facbd43d76f4f61f45b03284f09f/src/scripts/configure.sh#L1